### PR TITLE
metrics_registry decorators currently eat the return values

### DIFF
--- a/yunomi/core/metrics_registry.py
+++ b/yunomi/core/metrics_registry.py
@@ -1,4 +1,5 @@
 from time import time
+from functools import wraps
 
 from yunomi.core.counter import Counter
 from yunomi.core.histogram import Histogram
@@ -51,7 +52,7 @@ class MetricsRegistry(object):
                 self._histograms[key] = Histogram.get_biased()
             else:
                 self._histograms[key] = Histogram.get_uniform()
-                
+
         return self._histograms[key]
 
     def meter(self, key):
@@ -178,10 +179,11 @@ def count_calls(fn):
     @return: the decorated function
     @rtype: C{func}
     """
+    @wraps(fn)
     def wrapper(*args):
         counter("%s_calls" % fn.__name__).inc()
         try:
-            fn(*args)
+            return fn(*args)
         except:
             raise
     return wrapper
@@ -196,10 +198,11 @@ def meter_calls(fn):
     @return: the decorated function
     @rtype: C{func}
     """
+    @wraps(fn)
     def wrapper(*args):
         meter("%s_calls" % fn.__name__).mark()
         try:
-            fn(*args)
+            return fn(*args)
         except:
             raise
     return wrapper
@@ -214,12 +217,14 @@ def hist_calls(fn):
     @return: the decorated function
     @rtype: C{func}
     """
+    @wraps(fn)
     def wrapper(*args):
         _histogram = histogram("%s_calls" % fn.__name__)
         try:
             rtn = fn(*args)
             if type(rtn) in (int, float):
                 _histogram.update(rtn)
+            return rtn
         except:
             raise
     return wrapper
@@ -234,11 +239,12 @@ def time_calls(fn):
     @return: the decorated function
     @rtype: C{func}
     """
+    @wraps(fn)
     def wrapper(*args):
         _timer = timer("%s_calls" % fn.__name__)
         start = time()
         try:
-            fn(*args)
+            return fn(*args)
         except:
             raise
         finally:

--- a/yunomi/tests/test_metrics_registry.py
+++ b/yunomi/tests/test_metrics_registry.py
@@ -61,6 +61,7 @@ class MetricsRegistryTests(TestCase):
         time_mock.return_value = 10
         self.assertAlmostEqual(meter("test_calls").get_mean_rate(), 1.0)
 
+
     def test_hist_calls_decorator(self):
         @hist_calls
         def test(n):
@@ -81,7 +82,6 @@ class MetricsRegistryTests(TestCase):
         self.assertAlmostEqual(snapshot.get_99th_percentile(), 10.0)
         self.assertAlmostEqual(snapshot.get_999th_percentile(), 10.0)
 
-    
     @mock.patch("yunomi.core.metrics_registry.time")
     def test_time_calls_decorator(self, time_mock):
         time_mock.return_value = 0.0
@@ -101,3 +101,75 @@ class MetricsRegistryTests(TestCase):
         self.assertAlmostEqual(snapshot.get_98th_percentile(), 1.0)
         self.assertAlmostEqual(snapshot.get_99th_percentile(), 1.0)
         self.assertAlmostEqual(snapshot.get_999th_percentile(), 1.0)
+
+    def test_count_calls_decorator_returns_original_return_value(self):
+        @count_calls
+        def test():
+            return 1
+        self.assertEqual(test(), 1)
+
+    def test_meter_calls_decorator_returns_original_return_value(self):
+        @meter_calls
+        def test():
+            return 1
+        self.assertEqual(test(), 1)
+
+    def test_hist_calls_decorator_returns_original_return_value(self):
+        @hist_calls
+        def test():
+            return 1
+        self.assertEqual(test(), 1)
+
+    def test_time_calls_decorator_returns_original_return_value(self):
+        @time_calls
+        def test():
+            return 1
+        self.assertEqual(test(), 1)
+
+    def test_count_calls_decorator_keeps_function_name(self):
+        @count_calls
+        def test():
+            pass
+        self.assertEqual(test.__name__, 'test')
+
+    def test_meter_calls_decorator_keeps_function_name(self):
+        @meter_calls
+        def test():
+            pass
+        self.assertEqual(test.__name__, 'test')
+
+    def test_hist_calls_decorator_keeps_function_name(self):
+        @hist_calls
+        def test():
+            pass
+        self.assertEqual(test.__name__, 'test')
+
+    def test_time_calls_decorator_keeps_function_name(self):
+        @time_calls
+        def test():
+            pass
+        self.assertEqual(test.__name__, 'test')
+
+    def test_count_calls_decorator_propagates_errors(self):
+        @count_calls
+        def test():
+            raise Exception('what')
+        self.assertRaises(Exception, test)
+
+    def test_meter_calls_decorator_propagates_errors(self):
+        @meter_calls
+        def test():
+            raise Exception('what')
+        self.assertRaises(Exception, test)
+
+    def test_hist_calls_decorator_propagates_errors(self):
+        @hist_calls
+        def test():
+            raise Exception('what')
+        self.assertRaises(Exception, test)
+
+    def test_time_calls_decorator_propagates_errors(self):
+        @time_calls
+        def test():
+            raise Exception('what')
+        self.assertRaises(Exception, test)


### PR DESCRIPTION
Just added return statements in the decorators.  Also, the name of the decorated functions are currently `wrapper`, so I added the wraps decorator to the wrapper function (http://docs.python.org/library/functools.html#functools.wraps).
